### PR TITLE
Fixed Bug: Empty Plugin Name should not result in test failure.

### DIFF
--- a/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/runner/UpgradeTestRunnerIT.java
+++ b/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/runner/UpgradeTestRunnerIT.java
@@ -30,6 +30,8 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 import java.io.File;
@@ -57,6 +59,7 @@ public class UpgradeTestRunnerIT {
   private static Map<String, String> localInstalledPlugins = new HashMap<>();
   private boolean isFirstTest;
   private boolean isLastTest;
+  private static final Logger log = LoggerFactory.getLogger(UpgradeTestRunnerIT.class);
 
   public UpgradeTestRunnerIT(String version, boolean isFirstTest, boolean isLastTest,
                              Class<? extends ConnectorIT> connectorITClass) {
@@ -90,7 +93,7 @@ public class UpgradeTestRunnerIT {
         + ":" + version.toString(), destination, localInstalledPlugins);
 
     if (isFirstTest) {
-      connect = ConnectorUtils.startConnectCluster("cc-integration-test", pluginPath);
+      connect = ConnectorUtils.startConnectCluster("integration-tests", pluginPath);
       ConnectorIT.class.getDeclaredMethod("setup", EmbeddedConnectCluster.class)
           .invoke(connectorIT, connect);
     } else {
@@ -152,9 +155,14 @@ public class UpgradeTestRunnerIT {
 
   @Parameterized.Parameters(name = "{index}:{0}:{3}")
   public static Collection<Object[]> data() throws Exception {
-    String pluginName = EnvVariablesEnum.PLUGIN_NAME.value;
-    String reflectionPath = EnvVariablesEnum.REFLECTIONS_PATH.value;
+    String pluginName = EnvVariablesEnum.PLUGIN_NAME.getValueFromEnv();
+    String reflectionPath = EnvVariablesEnum.REFLECTIONS_PATH.getValueFromEnv();
+    String clonedRepoPath = EnvVariablesEnum.CLONED_REPO_PATH.getValueFromEnv();
 
+    if (pluginName.isEmpty() || clonedRepoPath.isEmpty()) {
+      log.info("Skipping Tests. Either PLUGIN_NAME or CLONED_REPO_PATH is empty.");
+      return new ArrayList<>();
+    }
     List<Class<? extends ConnectorIT>> connectorITs = new ArrayList<>();
     Reflections reflections = new Reflections(reflectionPath);
     Set<Class<? extends ConnectorIT>> classes = reflections.getSubTypesOf(ConnectorIT.class);
@@ -163,18 +171,18 @@ public class UpgradeTestRunnerIT {
       if (testPlugins.length > 0 && testPlugins[0].pluginName().equals(pluginName)) {
         pluginInfo = new PluginInfo(testPlugins[0].pluginName(),
             testPlugins[0].hubPath(), testPlugins[0].repoPath());
+        log.info("Found Integration tests : " + clazz.getSimpleName());
         connectorITs.add(clazz);
       }
     }
 
     if (connectorITs.isEmpty()) {
+      log.info("Skipping Tests. Found 0 integration test class annotated with {} class",
+          TestPlugin.class.getSimpleName());
       return new ArrayList<>();
     }
 
     upgradeTestHelper = new UpgradeTestHelper(pluginInfo);
-
-    String clonedRepoPath = EnvVariablesEnum.CLONED_REPO_PATH.value;
-
     List<Version> versionList = upgradeTestHelper.getAllTags(new File(clonedRepoPath));
     String projectVersion = upgradeTestHelper.getProjectVersion(new File(clonedRepoPath));
     Version latestTag = upgradeTestHelper.getLatestTag(versionList, projectVersion);
@@ -187,6 +195,8 @@ public class UpgradeTestRunnerIT {
     List<Object[]> params = new ArrayList<>();
     for (Class<? extends ConnectorIT> clazz : connectorITs) {
       // pass parameters acc. to constructor (version, firstTest, LastTest, ConnectorITClass)
+      log.info("{} will run for versions {} and {}", clazz.getSimpleName(),
+          latestTag.toString(), projectVersion);
       params.add(new Object[]{latestTag.toString(), true, false, clazz});
       params.add(new Object[]{projectVersion, false, true, clazz});
     }

--- a/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/runner/UpgradeTestRunnerIT.java
+++ b/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/runner/UpgradeTestRunnerIT.java
@@ -178,7 +178,7 @@ public class UpgradeTestRunnerIT {
 
     if (connectorITs.isEmpty()) {
       String exceptionMsg = String.format("Skipping Tests. Found 0 integration test class "
-          + "annotated with {} class and plugin {}", TestPlugin.class.getSimpleName(), pluginName);
+          + "annotated with %s class and plugin %s", TestPlugin.class.getSimpleName(), pluginName);
       throw new IllegalArgumentException(exceptionMsg);
     }
 

--- a/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/runner/UpgradeTestRunnerIT.java
+++ b/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/runner/UpgradeTestRunnerIT.java
@@ -160,7 +160,7 @@ public class UpgradeTestRunnerIT {
     String clonedRepoPath = EnvVariablesEnum.CLONED_REPO_PATH.getValueFromEnv();
 
     if (pluginName.isEmpty() || clonedRepoPath.isEmpty()) {
-      log.info("Skipping Tests. Either PLUGIN_NAME or CLONED_REPO_PATH is empty.");
+      log.warn("Skipping Tests. Either PLUGIN_NAME or CLONED_REPO_PATH is empty.");
       return new ArrayList<>();
     }
     List<Class<? extends ConnectorIT>> connectorITs = new ArrayList<>();
@@ -177,8 +177,8 @@ public class UpgradeTestRunnerIT {
     }
 
     if (connectorITs.isEmpty()) {
-      log.info("Skipping Tests. Found 0 integration test class annotated with {} class and plugin {}",
-          TestPlugin.class.getSimpleName(), pluginName);
+      log.warn("Skipping Tests. Found 0 integration test class annotated with {} class and"
+          + " plugin {}", TestPlugin.class.getSimpleName(), pluginName);
       return new ArrayList<>();
     }
 

--- a/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/runner/UpgradeTestRunnerIT.java
+++ b/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/runner/UpgradeTestRunnerIT.java
@@ -177,9 +177,9 @@ public class UpgradeTestRunnerIT {
     }
 
     if (connectorITs.isEmpty()) {
-      log.warn("Skipping Tests. Found 0 integration test class annotated with {} class and"
-          + " plugin {}", TestPlugin.class.getSimpleName(), pluginName);
-      return new ArrayList<>();
+      String exceptionMsg = String.format("Skipping Tests. Found 0 integration test class "
+          + "annotated with {} class and plugin {}", TestPlugin.class.getSimpleName(), pluginName);
+      throw new IllegalArgumentException(exceptionMsg);
     }
 
     upgradeTestHelper = new UpgradeTestHelper(pluginInfo);

--- a/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/runner/UpgradeTestRunnerIT.java
+++ b/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/runner/UpgradeTestRunnerIT.java
@@ -177,8 +177,8 @@ public class UpgradeTestRunnerIT {
     }
 
     if (connectorITs.isEmpty()) {
-      log.info("Skipping Tests. Found 0 integration test class annotated with {} class",
-          TestPlugin.class.getSimpleName());
+      log.info("Skipping Tests. Found 0 integration test class annotated with {} class and plugin {}",
+          TestPlugin.class.getSimpleName(), pluginName);
       return new ArrayList<>();
     }
 

--- a/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/util/EnvVariablesEnum.java
+++ b/connect-test-sdk-upgrade/src/main/java/io/confluent/connect/test/sdk/upgrade/util/EnvVariablesEnum.java
@@ -5,20 +5,24 @@
 package io.confluent.connect.test.sdk.upgrade.util;
 
 public enum EnvVariablesEnum {
-  VERSIONS_TO_RUN("VERSIONS_TO_RUN"),
-  BRANCH_TO_TEST("BRANCH_TO_TEST"),
-  PLUGIN_NAME("PLUGIN_NAME"),
-  REFLECTIONS_PATH("REFLECTIONS_PATH"),
-  CLONED_REPO_PATH("CLONED_REPO_PATH");
+  PLUGIN_NAME("PLUGIN_NAME",""),
+  REFLECTIONS_PATH("REFLECTIONS_PATH", "io.confluent"),
+  CLONED_REPO_PATH("CLONED_REPO_PATH", "");
 
-  public final String value;
+  public final String envVar;
+  public final String defaultValue;
 
-  EnvVariablesEnum(String value) {
-    String tmpValue = System.getenv(value);
-    if (value.equals("REFLECTIONS_PATH") && tmpValue.isEmpty()) {
-      tmpValue = "io.confluent";
+  EnvVariablesEnum(String envVar, String defaultValue) {
+    this.envVar = envVar;
+    this.defaultValue = defaultValue;
+  }
+
+  public String getValueFromEnv() {
+    String tmpValue = System.getenv(this.envVar);
+    if (tmpValue == null || tmpValue.isEmpty()) {
+      tmpValue = this.defaultValue;
     }
-    this.value = tmpValue;
+    return tmpValue;
   }
 
   public static String getLocalPluginPathVariable(String pluginName) {


### PR DESCRIPTION
## Problem
Test Run 1 :  PLUGIN_NAME =  "kafka-connect-something" , CLONE_REPO_PATH = "NOTHING"
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 59.183 s - in io.confluent.connect.test.sdk.upgrade.runner.UpgradeTestRunnerIT
[INFO] Results:
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```
Test Run 2: unset PLUGIN_NAME
```
Skipping Tests. Either PLUGIN_NAME or CLONED_REPO_PATH is empty. 
[INFO] Results:
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

Test Run 3: set PLUGIN_NAME = "kafka-connect-nothing"
It should fail because there is no such IT class annotated with kafka-connect-nothing
```
[ERROR] initializationError  Time elapsed: 0.035 s  <<< ERROR!
java.lang.IllegalArgumentException: Skipping Tests. Found 0 integration test class annotated with TestPlugin class and plugin kafka-connect-nothing
        at io.confluent.connect.test.sdk.upgrade.runner.UpgradeTestRunnerIT.data(UpgradeTestRunnerIT.java:182)



```
## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
