### PR TITLE
CC-27453: Revert internal aws-maven plugin changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,13 +46,6 @@
     </repository>
   </repositories>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <id>confluent</id>
-      <url>https://packages.confluent.io/maven/</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <licenses>
     <license>
       <name>Confluent Community License</name>
@@ -267,9 +260,9 @@
     </plugins>
     <extensions>
       <extension>
-        <groupId>io.confluent</groupId>
+        <groupId>org.springframework.build</groupId>
         <artifactId>aws-maven</artifactId>
-        <version>1.0.0</version>
+        <version>5.0.0.RELEASE</version>
       </extension>
     </extensions>
   </build>


### PR DESCRIPTION
## Problem
internal `aws-maven` ([repo](
![image](https://github.com/user-attachments/assets/0a7a7737-77a0-4489-846a-21084eff0e5a)
)) plugin is not working as expected

## Solution
Reverting back to external `aws-maven` ([repo](![image](https://github.com/user-attachments/assets/1d3e32c1-b5de-46d8-90a6-efd2b1c457c3))) usage. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
