### PR TITLE
CC-27453: Cherry pick from 0.1.x to master

### DIFF
--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.23</version>
+        <version>0.1.24-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.18-SNAPSHOT</version>
+        <version>0.1.18</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.11</version>
+        <version>0.1.12-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.27</version>
+        <version>0.1.28-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.25-SNAPSHOT</version>
+        <version>0.1.25</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.4</version>
+        <version>0.1.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.6</version>
+        <version>0.1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.20</version>
+        <version>0.1.21-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.17-SNAPSHOT</version>
+        <version>0.1.17</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.22</version>
+        <version>0.1.23-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.24</version>
+        <version>0.1.25-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.10-SNAPSHOT</version>
+        <version>0.1.10</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.27-SNAPSHOT</version>
+        <version>0.1.27</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.31-SNAPSHOT</version>
+        <version>0.1.31</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.31</version>
+        <version>0.1.32-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.28-SNAPSHOT</version>
+        <version>0.1.28</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.29</version>
+        <version>0.1.30-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.8</version>
+        <version>0.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.17</version>
+        <version>0.1.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.4-SNAPSHOT</version>
+        <version>0.1.4</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.18</version>
+        <version>0.1.19-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.30</version>
+        <version>0.1.31-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.20-SNAPSHOT</version>
+        <version>0.1.20</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.29-SNAPSHOT</version>
+        <version>0.1.29</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.7-SNAPSHOT</version>
+        <version>0.1.7</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.14</version>
+        <version>0.1.15-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.7</version>
+        <version>0.1.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.12</version>
+        <version>0.1.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.13-SNAPSHOT</version>
+        <version>0.1.13</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.5-SNAPSHOT</version>
+        <version>0.1.5</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.6-SNAPSHOT</version>
+        <version>0.1.6</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.23-SNAPSHOT</version>
+        <version>0.1.23</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.9-SNAPSHOT</version>
+        <version>0.1.9</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.30-SNAPSHOT</version>
+        <version>0.1.30</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.25</version>
+        <version>0.1.26-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.26-SNAPSHOT</version>
+        <version>0.1.26</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.28</version>
+        <version>0.1.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.13</version>
+        <version>0.1.14-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.8-SNAPSHOT</version>
+        <version>0.1.8</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.22-SNAPSHOT</version>
+        <version>0.1.22</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.5</version>
+        <version>0.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.16-SNAPSHOT</version>
+        <version>0.1.16</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.21-SNAPSHOT</version>
+        <version>0.1.21</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.11-SNAPSHOT</version>
+        <version>0.1.11</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.24-SNAPSHOT</version>
+        <version>0.1.24</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.19-SNAPSHOT</version>
+        <version>0.1.19</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.15-SNAPSHOT</version>
+        <version>0.1.15</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.16</version>
+        <version>0.1.17-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.21</version>
+        <version>0.1.22-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.9</version>
+        <version>0.1.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.12-SNAPSHOT</version>
+        <version>0.1.12</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.26</version>
+        <version>0.1.27-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.14-SNAPSHOT</version>
+        <version>0.1.14</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.15</version>
+        <version>0.1.16-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-common/pom.xml
+++ b/connect-test-sdk-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.19</version>
+        <version>0.1.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-common</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.12</version>
+        <version>0.1.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.13-SNAPSHOT</version>
+        <version>0.1.13</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.31-SNAPSHOT</version>
+        <version>0.1.31</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.14</version>
+        <version>0.1.15-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.11-SNAPSHOT</version>
+        <version>0.1.11</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.5</version>
+        <version>0.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.21-SNAPSHOT</version>
+        <version>0.1.21</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.16</version>
+        <version>0.1.17-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.10-SNAPSHOT</version>
+        <version>0.1.10</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.9-SNAPSHOT</version>
+        <version>0.1.9</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.17-SNAPSHOT</version>
+        <version>0.1.17</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.28-SNAPSHOT</version>
+        <version>0.1.28</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.31</version>
+        <version>0.1.32-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.15</version>
+        <version>0.1.16-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.6</version>
+        <version>0.1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.8</version>
+        <version>0.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.26</version>
+        <version>0.1.27-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.29</version>
+        <version>0.1.30-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.7-SNAPSHOT</version>
+        <version>0.1.7</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.19-SNAPSHOT</version>
+        <version>0.1.19</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.15-SNAPSHOT</version>
+        <version>0.1.15</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.7</version>
+        <version>0.1.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.29-SNAPSHOT</version>
+        <version>0.1.29</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.17</version>
+        <version>0.1.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.27</version>
+        <version>0.1.28-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.11</version>
+        <version>0.1.12-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.22-SNAPSHOT</version>
+        <version>0.1.22</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.20</version>
+        <version>0.1.21-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.20-SNAPSHOT</version>
+        <version>0.1.20</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.14-SNAPSHOT</version>
+        <version>0.1.14</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.23-SNAPSHOT</version>
+        <version>0.1.23</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.18-SNAPSHOT</version>
+        <version>0.1.18</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.19</version>
+        <version>0.1.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.9</version>
+        <version>0.1.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.30-SNAPSHOT</version>
+        <version>0.1.30</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.24-SNAPSHOT</version>
+        <version>0.1.24</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.18</version>
+        <version>0.1.19-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.22</version>
+        <version>0.1.23-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.25-SNAPSHOT</version>
+        <version>0.1.25</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.4</version>
+        <version>0.1.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.5-SNAPSHOT</version>
+        <version>0.1.5</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.8-SNAPSHOT</version>
+        <version>0.1.8</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.28</version>
+        <version>0.1.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.6-SNAPSHOT</version>
+        <version>0.1.6</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.21</version>
+        <version>0.1.22-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.4-SNAPSHOT</version>
+        <version>0.1.4</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.30</version>
+        <version>0.1.31-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.13</version>
+        <version>0.1.14-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.23</version>
+        <version>0.1.24-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.12-SNAPSHOT</version>
+        <version>0.1.12</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.16-SNAPSHOT</version>
+        <version>0.1.16</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.26-SNAPSHOT</version>
+        <version>0.1.26</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.24</version>
+        <version>0.1.25-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.25</version>
+        <version>0.1.26-SNAPSHOT</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-dataloss/pom.xml
+++ b/connect-test-sdk-dataloss/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-test-sdk-parent</artifactId>
-        <version>0.1.27-SNAPSHOT</version>
+        <version>0.1.27</version>
     </parent>
 
     <artifactId>connect-test-sdk-dataloss</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.8-SNAPSHOT</version>
+    <version>0.1.8</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.4-SNAPSHOT</version>
+    <version>0.1.4</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.4</version>
+    <version>0.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.21-SNAPSHOT</version>
+    <version>0.1.21</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.10</version>
+    <version>0.1.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.12</version>
+    <version>0.1.13-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.30</version>
+    <version>0.1.31-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.18</version>
+    <version>0.1.19-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.17</version>
+    <version>0.1.18-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.11</version>
+    <version>0.1.12-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.25</version>
+    <version>0.1.26-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.29-SNAPSHOT</version>
+    <version>0.1.29</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.12-SNAPSHOT</version>
+    <version>0.1.12</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.7</version>
+    <version>0.1.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.26-SNAPSHOT</version>
+    <version>0.1.26</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.9-SNAPSHOT</version>
+    <version>0.1.9</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.13-SNAPSHOT</version>
+    <version>0.1.13</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.5</version>
+    <version>0.1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.10-SNAPSHOT</version>
+    <version>0.1.10</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.25-SNAPSHOT</version>
+    <version>0.1.25</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.29</version>
+    <version>0.1.30-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.6-SNAPSHOT</version>
+    <version>0.1.6</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.20-SNAPSHOT</version>
+    <version>0.1.20</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.17-SNAPSHOT</version>
+    <version>0.1.17</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.19</version>
+    <version>0.1.20-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.11-SNAPSHOT</version>
+    <version>0.1.11</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.14-SNAPSHOT</version>
+    <version>0.1.14</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.28</version>
+    <version>0.1.29-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.7-SNAPSHOT</version>
+    <version>0.1.7</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.9</version>
+    <version>0.1.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.6</version>
+    <version>0.1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.15</version>
+    <version>0.1.16-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.13</version>
+    <version>0.1.14-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.16-SNAPSHOT</version>
+    <version>0.1.16</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.20</version>
+    <version>0.1.21-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.22-SNAPSHOT</version>
+    <version>0.1.22</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.14</version>
+    <version>0.1.15-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.31</version>
+    <version>0.1.32-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.16</version>
+    <version>0.1.17-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.5-SNAPSHOT</version>
+    <version>0.1.5</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.23</version>
+    <version>0.1.24-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.24</version>
+    <version>0.1.25-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.31-SNAPSHOT</version>
+    <version>0.1.31</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.23-SNAPSHOT</version>
+    <version>0.1.23</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.24-SNAPSHOT</version>
+    <version>0.1.24</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.26</version>
+    <version>0.1.27-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.21</version>
+    <version>0.1.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.28-SNAPSHOT</version>
+    <version>0.1.28</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.27</version>
+    <version>0.1.28-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.22</version>
+    <version>0.1.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.8</version>
+    <version>0.1.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.15-SNAPSHOT</version>
+    <version>0.1.15</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.27-SNAPSHOT</version>
+    <version>0.1.27</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.19-SNAPSHOT</version>
+    <version>0.1.19</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.18-SNAPSHOT</version>
+    <version>0.1.18</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/connect-test-sdk-upgrade/pom.xml
+++ b/connect-test-sdk-upgrade/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>kafka-connect-test-sdk-parent</artifactId>
     <groupId>io.confluent</groupId>
-    <version>0.1.30-SNAPSHOT</version>
+    <version>0.1.30</version>
   </parent>
 
   <artifactId>connect-test-sdk-upgrade</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.27-SNAPSHOT</version>
+  <version>0.1.27</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.27</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.27-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.27</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.16-SNAPSHOT</version>
+  <version>0.1.16</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.16</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.16-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.16</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.8</version>
+  <version>0.1.9-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.8</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.8</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.9-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.26-SNAPSHOT</version>
+  <version>0.1.26</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.26</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.26-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.26</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.15</version>
+  <version>0.1.16-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.15</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.15</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.16-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.18-SNAPSHOT</version>
+  <version>0.1.18</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.18</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.18-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.18</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.24-SNAPSHOT</version>
+  <version>0.1.24</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.24</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.24-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.24</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.5</version>
+  <version>0.1.6-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.5</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.5</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.6-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.26</version>
+  <version>0.1.27-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.26</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.26</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.27-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.18</version>
+  <version>0.1.19-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.18</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.18</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.19-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.25-SNAPSHOT</version>
+  <version>0.1.25</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.25</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.25-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.25</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.27</version>
+  <version>0.1.28-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.27</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.27</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.28-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.21</version>
+  <version>0.1.22-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.21</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.21</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.22-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.13</version>
+  <version>0.1.14-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.13</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.13</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.14-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.21-SNAPSHOT</version>
+  <version>0.1.21</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.21</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.21-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.21</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.14-SNAPSHOT</version>
+  <version>0.1.14</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.14</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.14-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.14</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.31-SNAPSHOT</version>
+  <version>0.1.31</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.31</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.31-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.31</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.25</version>
+  <version>0.1.26-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.25</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.25</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.26-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.31</version>
+  <version>0.1.32-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.31</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.31</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.32-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.13-SNAPSHOT</version>
+  <version>0.1.13</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.13</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.13-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.13</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.29-SNAPSHOT</version>
+  <version>0.1.29</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.29</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.29-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.29</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.22</version>
+  <version>0.1.23-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.22</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.22</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.23-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.16</version>
+  <version>0.1.17-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.16</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.16</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.17-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.6</version>
+  <version>0.1.7-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.6</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.6</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.7-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.19-SNAPSHOT</version>
+  <version>0.1.19</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.19</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.19-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.19</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.8-SNAPSHOT</version>
+  <version>0.1.8</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.8</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.8-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.8</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.29</version>
+  <version>0.1.30-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.29</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.29</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.30-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.23</version>
+  <version>0.1.24-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.23</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.23</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.24-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.10</version>
+  <version>0.1.11-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.10</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.10</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.11-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.11</version>
+  <version>0.1.12-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.11</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.11</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.12-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.20</version>
+  <version>0.1.21-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.20</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.20</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.21-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.7-SNAPSHOT</version>
+  <version>0.1.7</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.7</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.7-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.7</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.4</version>
+  <version>0.1.5-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.4</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.4</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.5-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.12-SNAPSHOT</version>
+  <version>0.1.12</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.12</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.12-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.12</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.12</version>
+  <version>0.1.13-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.12</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.12</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.13-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.11-SNAPSHOT</version>
+  <version>0.1.11</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.11</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.11-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.11</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.22-SNAPSHOT</version>
+  <version>0.1.22</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.22</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.22-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.22</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.4-SNAPSHOT</version>
+  <version>0.1.4</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.4</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.4-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.4</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.10-SNAPSHOT</version>
+  <version>0.1.10</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.10</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.10-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.10</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.28</version>
+  <version>0.1.29-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.28</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.28</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.29-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.7</version>
+  <version>0.1.8-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.7</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.7</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.8-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.15-SNAPSHOT</version>
+  <version>0.1.15</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.15</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.15-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.15</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.6-SNAPSHOT</version>
+  <version>0.1.6</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.6</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.6-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.6</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.28-SNAPSHOT</version>
+  <version>0.1.28</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.28</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.28-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.28</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.30</version>
+  <version>0.1.31-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.30</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.30</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.31-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.30-SNAPSHOT</version>
+  <version>0.1.30</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.30</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.30-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.30</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.17-SNAPSHOT</version>
+  <version>0.1.17</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.17</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.17-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.17</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.23-SNAPSHOT</version>
+  <version>0.1.23</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.23</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.23-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.23</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.17</version>
+  <version>0.1.18-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.17</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.17</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.18-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.24</version>
+  <version>0.1.25-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.24</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.24</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.25-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.5-SNAPSHOT</version>
+  <version>0.1.5</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.5</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.5-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.5</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.19</version>
+  <version>0.1.20-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.19</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.19</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.20-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.9</version>
+  <version>0.1.10-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.9</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.9</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.10-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.9-SNAPSHOT</version>
+  <version>0.1.9</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.9</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.9-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.9</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.20-SNAPSHOT</version>
+  <version>0.1.20</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>0.1.x</tag>
+    <tag>v0.1.20</tag>
   </scm>
 
   <repositories>
@@ -68,7 +68,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.20-SNAPSHOT</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.20</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>kafka-connect-test-sdk-parent</artifactId>
   <packaging>pom</packaging>
   <name>kafka-connect-test-sdk-parent</name>
-  <version>0.1.14</version>
+  <version>0.1.15-SNAPSHOT</version>
   <description>Contains Common Test functionality for Connect.</description>
   <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
   <inceptionYear>2023</inceptionYear>
@@ -35,7 +35,7 @@
     <connection>scm:git:https://github.com/confluentinc/kafka-connect-test-sdk.git</connection>
     <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-test-sdk.git</developerConnection>
     <url>https://github.com/confluentinc/kafka-connect-test-sdk</url>
-    <tag>v0.1.14</tag>
+    <tag>0.1.x</tag>
   </scm>
 
   <repositories>
@@ -75,7 +75,7 @@
     to verify that the two transitive jetty dependencies can coexist (this is a concern
     for integration tests only. packaging builds are not affected by this problem) -->
     <cometd.version>4.0.9</cometd.version>
-    <connect.test.sdk.common.version>0.1.14</connect.test.sdk.common.version>
+    <connect.test.sdk.common.version>0.1.15-SNAPSHOT</connect.test.sdk.common.version>
     <dependency.check.skip>true</dependency.check.skip>
   </properties>
 


### PR DESCRIPTION
## Overview
Cherry pick changes from 0.1.x to master for aws-maven plugin.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
