### PR TITLE
CC-27453: Use seahen s3 wagon plugin to upload artifacts on S3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,9 +269,9 @@
     </plugins>
     <extensions>
       <extension>
-        <groupId>fi.yle.tools</groupId>
-        <artifactId>aws-maven</artifactId>
-        <version>1.4.1</version>
+        <groupId>com.github.seahen</groupId>
+        <artifactId>maven-s3-wagon</artifactId>
+        <version>1.3.3</version>
       </extension>
     </extensions>
   </build>


### PR DESCRIPTION
## Problem
Current aws-maven plugin does not support IAM roles

## Solution
Use seahen s3 wagon plugin to upload artifacts on S3

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
