### PR TITLE
CC-27453: Reverted aws-maven plugin changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,15 +82,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <id>yle-public</id>
-      <name>Yle public repository</name>
-      <url>https://maven.yle.fi/release</url>
-      <layout>default</layout>
-    </pluginRepository>
-  </pluginRepositories>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -269,9 +260,9 @@
     </plugins>
     <extensions>
       <extension>
-        <groupId>com.github.seahen</groupId>
-        <artifactId>maven-s3-wagon</artifactId>
-        <version>1.3.3</version>
+        <groupId>org.springframework.build</groupId>
+        <artifactId>aws-maven</artifactId>
+        <version>5.0.0.RELEASE</version>
       </extension>
     </extensions>
   </build>


### PR DESCRIPTION
## Problem
aws-maven plugin is not compatible with IAM Roles to upload S3 buckets.

## Solution
Tried many plugins but it did not work. Will use aws cli to upload artifacts to S3 so reverting back the changes done in last commit.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
